### PR TITLE
Specifying bable-register path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,8 +162,11 @@ function getHTML (options) {
         extensions: [
             '.jsx',
         ],
+        // needed when running sashay from another folder
+        only: './ui',
         presets: [
             'react',
+            'es2015',
         ],
     })
     var React = require('react')


### PR DESCRIPTION
Running Sashay from hotlanta wasn't parsing jsx files.
