### PR TITLE
Render empty application/json bodies.

### DIFF
--- a/lib/cli/__test__/fixtures/empty-response.raml
+++ b/lib/cli/__test__/fixtures/empty-response.raml
@@ -1,0 +1,14 @@
+#%RAML 0.8
+---
+baseUri: example.com
+title: foo
+version: foo
+
+/foo:
+  displayName: a
+  delete:
+    displayName: b
+    responses:
+      204:
+        body:
+          application/json: !!null

--- a/lib/cli/__test__/transform.spec.js
+++ b/lib/cli/__test__/transform.spec.js
@@ -2,6 +2,7 @@ var _ = require('lodash')
 var emptyScalar = require('./utils').emptyScalar
 var expand = require('../expand')
 var expect = require('chai').expect
+var get = require('lodash/get')
 var transform = require('../transform')
 var path = require('path')
 
@@ -142,6 +143,39 @@ describe('transform()', function () {
             .caught(function (err) {
                 expect(err).to.be.an.instanceof(Error)
                 expect(err.message).to.match(/^A link in foo section points to the invalid anchor foo123.*/)
+                return done()
+            })
+            .caught(done)
+    })
+
+    it('should transform empty response body', function (done) {
+        var options = {
+            source: path.resolve(__dirname, './fixtures/empty-response.raml'),
+        }
+        expand(options)
+            .then(function (res) {
+                return transform(_.extend(options, { schema: res }))
+            })
+            .then(function (res) {
+                expect(get(res, ['groups', 0, 'methods', 0])).to.deep.equal({
+                    absoluteUri: 'example.com/foo',
+                    displayName: 'b',
+                    method: 'delete',
+                    protocols: [
+                        'HTTP',
+                    ],
+                    responses: {
+                        204: {
+                            body: {
+                                'application/json': {
+                                    example: undefined,
+                                    payload: undefined,
+                                },
+                            },
+                        },
+                    },
+                    slug: 'foo.delete',
+                })
                 return done()
             })
             .caught(done)

--- a/lib/cli/transform.js
+++ b/lib/cli/transform.js
@@ -102,12 +102,24 @@ function getMethods (relativeUri, relativeUriPathSegments, resource) {
             }
             var responseSchemas = _.chain(method.responses)
                 .map(function (response, code) {
-                    if (!_.has(response, ['body', 'application/json', 'schema']) || _.get(response, ['body', 'application/json', 'schema']) === '{}') return null
+                    if (!_.has(response, ['body', 'application/json'])) return null
+                    var schemaKeyPath = [
+                        'body',
+                        'application/json',
+                        'schema',
+                    ]
+                    var schema = _.has(response, schemaKeyPath)
+                        ? JSON.parse(_.get(response, schemaKeyPath))
+                        : undefined
                     return [code, {
                         body: {
                             'application/json': {
-                                payload: transform(JSON.parse(response.body['application/json'].schema)),
-                                example: response.body['application/json'].example,
+                                payload: transform(schema),
+                                example: _.get(response, [
+                                    'body',
+                                    'application/json',
+                                    'example',
+                                ]),
                             },
                         },
                     }]

--- a/lib/cli/validate-raml.js
+++ b/lib/cli/validate-raml.js
@@ -35,12 +35,13 @@ function validateResource (relativeUriPathSegments, raml) {
 
 function validateMethod (relativeUriPathSegments, raml) {
     var path = relativeUriPathSegments.concat(raml.method)
+    var successResponseJsonSchema = Joi.object().keys({
+        example: Joi.string(),
+        schema: Joi.string().required(),
+    })
     var successResponseSchema = Joi.object().keys({
         body: Joi.object().unknown(false).keys({
-            'application/json': Joi.object().keys({
-                example: Joi.string(),
-                schema: Joi.string().required(),
-            }).required(),
+            'application/json': Joi.alternatives().try(null, successResponseJsonSchema).required(),
         }),
     }).required()
     var methodSchema = Joi.object().keys({


### PR DESCRIPTION
Adds support for `204 DELETE`. RAML should look like:

```
responses:
  204:
    description: A successful delete
    body:
      application/json: !!null
```
