### PR TITLE
API-652 Verify RAML is parseable before returning.

### DIFF
--- a/lib/cli/__test__/fixtures/dereference/result.raml
+++ b/lib/cli/__test__/fixtures/dereference/result.raml
@@ -43,6 +43,7 @@ documentation:
                   "type": "object",
                   "properties": {
                     "a": {
+                      "description": "A test string that includes special replacement pattern `$`\n",
                       "type": "string"
                     }
                   }

--- a/lib/cli/__test__/fixtures/dereference/schemas/foo/item.yaml
+++ b/lib/cli/__test__/fixtures/dereference/schemas/foo/item.yaml
@@ -1,4 +1,6 @@
 type: object
 properties:
   a:
+    description: |
+      A test string that includes special replacement pattern `$`
     type: string

--- a/lib/cli/raml.js
+++ b/lib/cli/raml.js
@@ -77,7 +77,7 @@ function dereferenceRAML (file, parentIndent) {
         var replaceWith = (extension !== 'raml') ? ' |\n' : '\n'
 
         replaceWith += dereferenceRAML(includePath, indent)
-        content = content.replace(includeValue, replaceWith)
+        content = content.replace(includeValue, function () { return replaceWith }) // eslint-disable-line no-loop-func
         matches = content.match(RAML_INCLUDE_RE)
     }
 


### PR DESCRIPTION
https://percolate.atlassian.net/browse/API-652

In JavaScript, the behavior of `String.prototype.replace` can be modified by using "special replacement patterns". In this case, a property description contained markdown like:

```
`^asset:\d[\d_-]*$`
```

The `replace()` method treats the string

```
$`
```

as a special pattern that was causing incorrect output. I updated the `replace()` call to use a function parameter to ignore special patterns.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter.