### PR TITLE
Use Only Required Query Parameters in Curl Example

### DIFF
--- a/lib/ui/__test__/curl.spec.js
+++ b/lib/ui/__test__/curl.spec.js
@@ -2,7 +2,7 @@ var createElement = require('react').createElement
 var expect = require('chai').expect
 var Curl = require('components/curl.jsx')
 
-var CURL_CMD = `curl "http://example.com?scope_ids={scope_ids}&type={type}" \\
+var CURL_CMD = `curl "http://example.com?type={type}" \\
   -X "GET" \\
   -H "Authorization: Bearer {your_access_token}" \\
   -H "Content-type: application/json; charset=utf-8"`

--- a/lib/ui/__test__/helper.spec.js
+++ b/lib/ui/__test__/helper.spec.js
@@ -257,14 +257,7 @@ describe('helper', function () {
                 scope_ids: { required: false },
                 type: { required: true },
                 fields: { required: false },
-            })).to.equal('example.com?scope_ids={scope_ids}&type={type}')
-        })
-
-        it('should only add scope_ids for GET', function () {
-            expect(addRequiredQueryParameters('example.com', 'post', {
-                required: false,
-                displayName: 'scope_ids',
-            })).to.equal('example.com')
+            })).to.equal('example.com?type={type}')
         })
 
         it('should support no params', function () {

--- a/lib/ui/helper.js
+++ b/lib/ui/helper.js
@@ -84,7 +84,7 @@ function parseRoute (pathname) {
 function addRequiredQueryParameters (url, method, params) {
     var queryString = _.chain(params)
         .map(function (param, key) {
-            if (param.required || method === 'get' && key === 'scope_ids') {
+            if (param.required) {
                 return `${key}={${key}}`
             }
         })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sashay",
   "description": "A documentation generator for the Percolate API.",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "engines": {
     "node": "4.2.x",
     "npm": "2.14.x"


### PR DESCRIPTION
The `v5/variant` endpoint doesn't use the `scope_ids` query parameter but Sashay currently automatically injects it into the curl example.  This [looks weird](https://hello.percolate.com/docs/api/#/method.api.v5.variant) because the example doesn't match with the actual specification.